### PR TITLE
Performance Test added via JMH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,23 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.19</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -47,7 +64,31 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>run-benchmarks</id>
+            <phase>integration-test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <classpathScope>test</classpathScope>
+              <executable>${java.home}/bin/java</executable>
+              <arguments>
+                <argument>-classpath</argument>
+                <classpath/>
+                <argument>org.openjdk.jmh.Main</argument>
+                <argument>.*</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/test/java/org/apache/otto/EntropyUtilPerfTest.java
+++ b/src/test/java/org/apache/otto/EntropyUtilPerfTest.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.otto;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Mode.AverageTime)
+@OperationsPerInvocation(1)
+public class EntropyUtilPerfTest {
+  public static final int N = 10000;
+  private static Random rng = new Random(0);
+
+
+  static List<Map<?, Integer>> inputData = new ArrayList<Map<?, Integer>>(){{
+    for(int i = 0;i < N;++i) {
+      String randomString = RandomStringUtils.randomAlphanumeric(100, 200);
+      add(stringToCount(randomString));
+    }
+  }};
+  public static Map<String, Integer> stringToCount(String s) {
+    Map<String, Integer> ret = new HashMap<>();
+    for(int i = 0;i < s.length();++i) {
+      String key = "" + s.charAt(i);
+      ret.put(key, ret.getOrDefault(key, 0) + 1);
+    }
+    return ret;
+  }
+
+  static Map<?, Integer> getData() {
+    return inputData.get(rng.nextInt(inputData.size()));
+  }
+
+  @Benchmark
+  public void nonStream() {
+    EntropyUtil.entropy(getData(), 2);
+  }
+
+  @Benchmark
+  public void stream() {
+    EntropyUtil.stream_entropy(getData(), 2);
+  }
+}


### PR DESCRIPTION
Just to satisfy my curiosity, I wanted to understand the performance implications of streaming vs non-streaming implementations, so I added a JMH test to drive the two functions.

Run via `mvn clean package integration-test`

Interesting results too!

```
Result "org.apache.otto.EntropyUtilPerfTest.stream":
  4550.125 ±(99.9%) 15.792 ns/op [Average]
  (min, avg, max) = (4406.028, 4550.125, 4815.022), stdev = 66.866
  CI (99.9%): [4534.333, 4565.918] (assumes normal distribution)


# Run complete. Total time: 00:13:38

Benchmark                      Mode  Cnt     Score    Error  Units
EntropyUtilPerfTest.nonStream  avgt  200  3337.024 ± 18.178  ns/op
EntropyUtilPerfTest.stream     avgt  200  4550.125 ± 15.792  ns/op
```
Looks like streaming is around ~36% slower.