### PR TITLE
add tests with static data

### DIFF
--- a/src/test/java/org/apache/otto/EntropyUtilPerfTest.java
+++ b/src/test/java/org/apache/otto/EntropyUtilPerfTest.java
@@ -51,6 +51,8 @@ public class EntropyUtilPerfTest {
     return inputData.get(rng.nextInt(inputData.size()));
   }
 
+  static Map<?, Integer> DATA = inputData.get(rng.nextInt(inputData.size()));
+
   @Benchmark
   public void nonStream() {
     EntropyUtil.entropy(getData(), 2);
@@ -60,4 +62,16 @@ public class EntropyUtilPerfTest {
   public void stream() {
     EntropyUtil.stream_entropy(getData(), 2);
   }
+
+  @Benchmark
+  public void nonStreamPreFetch() {
+    EntropyUtil.entropy(DATA, 2);
+  }
+
+  @Benchmark
+  public void streamPreFetch() {
+    EntropyUtil.stream_entropy(DATA, 2);
+  }
+
+
 }


### PR DESCRIPTION
```

Benchmark                              Mode  Cnt     Score     Error  Units
EntropyUtilPerfTest.nonStream          avgt  200  3298.686 ±  26.929  ns/op
EntropyUtilPerfTest.nonStreamPreFetch  avgt  200  2564.177 ±  37.472  ns/op
EntropyUtilPerfTest.stream             avgt  200  4767.643 ± 130.903  ns/op
EntropyUtilPerfTest.streamPreFetch     avgt  200  3774.376 ±  46.187  ns/op
```

@cestella 